### PR TITLE
Replace the video link of the Deal or No Deal entry with a shorter edit

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
 					DEBT ADDED
 				</div>
 				<ul>
-					<li>$2,649,727,215 - the worst <a href="https://youtu.be/BQaSlD_UFRU?t=10675">Deal or No Deal</a> play of all time. Debt doubled on Nov. 25, 2020</li>
+					<li>$2,649,727,215 - the worst <a href="https://youtu.be/WfuNOa8dGGE">Deal or No Deal</a> play of all time. Debt doubled on Nov. 25, 2020</li>
 					<li>$250,000,000 - Jerma bets 250 million that <a href="https://youtu.be/BQaSlD_UFRU?t=7300">he hasn't said "GAS" more than SAW's script.</a></li>
 					<li>$700,000 - 50K for every minute he attempted the "<a href="https://youtu.be/azDfFoaFo-c?t=578">Be a good hitman</a>" deal. (14 Minutes)</li>
 					<br>


### PR DESCRIPTION
SuperDazza uploaded a supercut version of the events of the [Deal or No Deal](https://youtu.be/WfuNOa8dGGE) debt challenge today, and I thought it'd be easier for newcomers to watch that instead of the long stream clip.